### PR TITLE
Od dev2

### DIFF
--- a/pioreactor/background_jobs/growth_rate_calculating.py
+++ b/pioreactor/background_jobs/growth_rate_calculating.py
@@ -104,6 +104,10 @@ class GrowthRateCalculator(BackgroundJob):
 
     def on_ready(self) -> None:
         # Initialization when job is marked as READY.
+        # this is here since the below is long running, and if kept in the init(), there is a large window where
+        # two growth_rate_calculating jobs can be started.
+        # Note that this function runs in the __post__init__, i.e. in the same frame as __init__, i.e.
+        # when we initialize the class. Thus, we need to handle errors and cleanup resources gracefully.
         if hasattr(self, "ukf"):
             return
 

--- a/pioreactor/background_jobs/growth_rate_calculating.py
+++ b/pioreactor/background_jobs/growth_rate_calculating.py
@@ -410,7 +410,10 @@ class GrowthRateCalculator(BackgroundJob):
             if raw_signal is None:
                 raise ValueError(f"Missing 'od' value for channel {channel}. Observations: {observations}")
                 
-            dynamic_zero_offset = values.get("dynamic_zero_offset")  
+            dynamic_zero_offset = values.get("dynamic_zero_offset")
+            
+            self.logger.debug(f"raw value:`{raw_signal}` normalization mean: '{self.od_normalization_factors["1"]}' dynamic zero offset: '{dynamic_zero_offset}'")
+
             if dynamic_zero_offset is None:
                 # Scale the 'od' value using normalization factors and blanks
                 scaled_signals[channel] = _scale_and_shift(

--- a/pioreactor/background_jobs/growth_rate_calculating.py
+++ b/pioreactor/background_jobs/growth_rate_calculating.py
@@ -52,7 +52,7 @@ from pioreactor import types as pt
 from pioreactor import whoami
 from pioreactor.actions.od_blank import od_statistics
 from pioreactor.background_jobs.base import BackgroundJob
-from pioreactor.background_jobs.od_reading import VALID_PD_ANGLES
+from pioreactor.background_jobs.od_reading import VALID_PD_ANGLES, ODReader
 from pioreactor.config import config
 from pioreactor.pubsub import QOS
 from pioreactor.pubsub import subscribe

--- a/pioreactor/background_jobs/growth_rate_calculating.py
+++ b/pioreactor/background_jobs/growth_rate_calculating.py
@@ -103,7 +103,8 @@ class GrowthRateCalculator(BackgroundJob):
         self.stats_samples_per_second = config.getfloat(
             "od_reading.config", "stats_samples_per_second", fallback=self.samples_per_second
         )  # New variable to handle separate statistics sampling rate
-
+        self.expected_dt = 1 / (60 * 60 * self.samples_per_second)
+        
     def on_ready(self) -> None:
         # this is here since the below is long running, and if kept in the init(), there is a large window where
         # two growth_rate_calculating jobs can be started.

--- a/pioreactor/background_jobs/growth_rate_calculating.py
+++ b/pioreactor/background_jobs/growth_rate_calculating.py
@@ -412,7 +412,7 @@ class GrowthRateCalculator(BackgroundJob):
                 
             dynamic_zero_offset = values.get("dynamic_zero_offset")
             
-            self.logger.debug(f"raw value:`{raw_signal}` normalization mean: '{self.od_normalization_factors["1"]}' dynamic zero offset: '{dynamic_zero_offset}'")
+            self.logger.debug(f"raw value:`{raw_signal}` normalization mean: '{self.od_normalization_factors['1']}' dynamic zero offset: '{dynamic_zero_offset}'")
 
             if dynamic_zero_offset is None:
                 # Scale the 'od' value using normalization factors and blanks

--- a/pioreactor/background_jobs/growth_rate_calculating.py
+++ b/pioreactor/background_jobs/growth_rate_calculating.py
@@ -251,47 +251,47 @@ class GrowthRateCalculator(BackgroundJob):
                 "Is there an OD Reading that is 0? Maybe there's a loose photodiode connection?"
             )
 
-def _compute_and_cache_od_statistics(
-    self,
-) -> tuple[dict[pt.PdChannel, float], dict[pt.PdChannel, float]]:
-    # why sleep? Users sometimes spam jobs, and if stirring and gr start closely there can be a race to secure HALL_SENSOR. This gives stirring priority.
-    sleep(1)  # i dont use stirring so dont need 5 sec
+    def _compute_and_cache_od_statistics(
+        self,
+    ) -> tuple[dict[pt.PdChannel, float], dict[pt.PdChannel, float]]:
+        # why sleep? Users sometimes spam jobs, and if stirring and gr start closely there can be a race to secure HALL_SENSOR. This gives stirring priority.
+        sleep(1)  # i dont use stirring so dont need 5 sec
 
-    # Save the original sampling interval
-    original_interval = 1 / config.getfloat("od_reading.config", "samples_per_second")
+        # Save the original sampling interval
+        original_interval = 1 / config.getfloat("od_reading.config", "samples_per_second")
 
-    # Adjust the sampling rate for statistics collection
-    self.od_reader.update_sampling_interval(1 / config.getfloat(
-        "od_reading.config", "stats_samples_per_second", fallback=1 / original_interval
-    ))
-    self.logger.info(f"Sampling rate switched to stats_samples_per_second for OD normalization metrics.")
+        # Adjust the sampling rate for statistics collection
+        self.od_reader.update_sampling_interval(1 / config.getfloat(
+            "od_reading.config", "stats_samples_per_second", fallback=1 / original_interval
+        ))
+        self.logger.info(f"Sampling rate switched to stats_samples_per_second for OD normalization metrics.")
 
-    try:
-        means, variances = od_statistics(
-            self._yield_od_readings_from_mqtt(),
-            action_name="od_normalization",
-            n_samples=config.getint(
-                "growth_rate_calculating.config", "samples_for_od_statistics", fallback=35
-            ),
-            unit=self.unit,
-            experiment=self.experiment,
-            logger=self.logger,
-        )
-        self.logger.info("Completed OD normalization metrics.")
-    finally:
-        # Restore the original sampling interval
-        self.od_reader.update_sampling_interval(original_interval)
-        self.logger.info("Sampling rate restored to samples_per_second.")
+        try:
+            means, variances = od_statistics(
+                self._yield_od_readings_from_mqtt(),
+                action_name="od_normalization",
+                n_samples=config.getint(
+                    "growth_rate_calculating.config", "samples_for_od_statistics", fallback=35
+                ),
+                unit=self.unit,
+                experiment=self.experiment,
+                logger=self.logger,
+            )
+            self.logger.info("Completed OD normalization metrics.")
+        finally:
+            # Restore the original sampling interval
+            self.od_reader.update_sampling_interval(original_interval)
+            self.logger.info("Sampling rate restored to samples_per_second.")
 
-    with local_persistant_storage("od_normalization_mean") as cache:
-        if self.experiment not in cache:
-            cache[self.experiment] = dumps(means)
+        with local_persistant_storage("od_normalization_mean") as cache:
+            if self.experiment not in cache:
+                cache[self.experiment] = dumps(means)
 
-    with local_persistant_storage("od_normalization_variance") as cache:
-        if self.experiment not in cache:
-            cache[self.experiment] = dumps(variances)
+        with local_persistant_storage("od_normalization_variance") as cache:
+            if self.experiment not in cache:
+                cache[self.experiment] = dumps(variances)
 
-    return means, variances
+        return means, variances
 
 
     def get_initial_values(self) -> tuple[float, float, float]:

--- a/pioreactor/background_jobs/od_reading.py
+++ b/pioreactor/background_jobs/od_reading.py
@@ -103,6 +103,7 @@ from pioreactor.background_jobs.base import LoggerMixin
 from pioreactor.config import config
 from pioreactor.hardware import ADC_CHANNEL_FUNCS
 from pioreactor.pubsub import publish
+from pioreactor.pubsub import QOS
 from pioreactor.utils import argextrema
 from pioreactor.utils import local_intermittent_storage
 from pioreactor.utils import local_persistant_storage
@@ -1158,7 +1159,7 @@ class ODReader(BackgroundJob):
                 self.logger.warning(f"Ignored invalid sampling interval: {new_interval}")
         except ValueError as e:
             self.logger.error(f"Failed to decode sampling interval: {e}")
-            
+
     def update_sampling_interval(self, new_interval: float) -> None:
         """
         Dynamically updates the sampling interval for the ADC reader.

--- a/pioreactor/background_jobs/od_reading.py
+++ b/pioreactor/background_jobs/od_reading.py
@@ -486,6 +486,15 @@ class ADCReader(LoggerMixin):
 
             batched_estimates_: PdChannelToVoltage = {}
 
+            if self.most_appropriate_AC_hz is None:
+                self.most_appropriate_AC_hz = self.determine_most_appropriate_AC_hz(
+                    timestamps, aggregated_signals
+                )
+
+            if os.environ.get("DEBUG") is not None:
+                self.logger.debug(f"{timestamps=}")
+                self.logger.debug(f"{aggregated_signals=}")
+                
             for channel in self.channels:
                 # Use dynamic zero offset if provided, otherwise fallback to stored adc_offsets
                 offset = (

--- a/pioreactor/background_jobs/od_reading.py
+++ b/pioreactor/background_jobs/od_reading.py
@@ -1172,7 +1172,7 @@ class ODReader(BackgroundJob):
             self.record_from_adc,
             job_name=self.job_name,
             run_immediately=False,
-        ).start()
+        )
 
 
     def start_ir_led(self) -> None:

--- a/pioreactor/background_jobs/od_reading.py
+++ b/pioreactor/background_jobs/od_reading.py
@@ -226,30 +226,24 @@ class ADCReader(LoggerMixin):
         return testing_signals
 
     def compute_dynamic_zero_offset(self) -> dict[pt.PdChannel, float]:
-        """
-        Compute the dynamic zero offset (zero-light condition) using a small sample size.
-        This is calculated before each measurement to dynamically adjust for current conditions.
-
-        Returns:
-            A dictionary of dynamic offsets for each photodiode channel.
-        """
         offsets = {}
         sample_count = 32  # Number of samples to average for dynamic offset
         aggregated_signals = {channel: [] for channel in self.channels}
 
-        # Collect multiple samples
+        # Collect multiple samples in raw ADC counts
         for _ in range(sample_count):
             for pd_channel in self.channels:
                 adc_channel = ADC_CHANNEL_FUNCS[pd_channel]
                 signal = self.adc.read_from_channel(adc_channel)
-                aggregated_signals[pd_channel].append(self.adc.from_raw_to_voltage(signal))
+                aggregated_signals[pd_channel].append(signal)
 
-        # Calculate mean offset for each channel
+        # Calculate mean offset in raw ADC counts for each channel
         for channel, signals in aggregated_signals.items():
             offsets[channel] = sum(signals) / len(signals)
 
-        self.logger.debug(f"Dynamic zero offsets computed: {offsets}")
+        self.logger.debug(f"Dynamic zero offsets (raw ADC counts): {offsets}")
         return offsets
+
 
     def set_offsets(self, batched_readings: PdChannelToVoltage) -> None:
         """

--- a/pioreactor/background_jobs/od_reading.py
+++ b/pioreactor/background_jobs/od_reading.py
@@ -494,7 +494,7 @@ class ADCReader(LoggerMixin):
             if os.environ.get("DEBUG") is not None:
                 self.logger.debug(f"{timestamps=}")
                 self.logger.debug(f"{aggregated_signals=}")
-                
+
             for channel in self.channels:
                 # Use dynamic zero offset if provided, otherwise fallback to stored adc_offsets
                 offset = (
@@ -531,6 +531,9 @@ class ADCReader(LoggerMixin):
             self.check_on_max(max_signal)
             self.batched_readings = batched_estimates_
 
+            # the max signal should determine the ADS1x15's gain
+            self.max_signal_moving_average.update(max_signal)
+            
             # Update gain dynamically based on the maximum signal
             if self.dynamic_gain:
                 m = self.max_signal_moving_average.get_latest()

--- a/pioreactor/background_jobs/od_reading.py
+++ b/pioreactor/background_jobs/od_reading.py
@@ -1150,7 +1150,7 @@ class ODReader(BackgroundJob):
                             angle=angle,
                             timestamp=timestamp_of_readings,
                             channel=channel,
-                            dynamic_zero_offset=dynamic_zero_offset
+                            dynamic_zero_offset=dynamic_zero_offset[channel]
                         )
                         for channel, angle in self.channel_angle_map.items()
                     },

--- a/pioreactor/structs.py
+++ b/pioreactor/structs.py
@@ -123,6 +123,16 @@ class ODReadings(JSONPrintedStruct):
     timestamp: t.Annotated[datetime, Meta(tz=True)]
     ods: dict[pt.PdChannel, ODReading]
 
+class Dynamic_Offset_ODReading(JSONPrintedStruct):
+    timestamp: t.Annotated[datetime, Meta(tz=True)]
+    angle: pt.PdAngle
+    od: pt.OD
+    channel: pt.PdChannel
+    dynamic_zero_offset: pt.OD
+
+class Dynamic_Offset_ODReadings(JSONPrintedStruct):
+    timestamp: t.Annotated[datetime, Meta(tz=True)]
+    ods: dict[pt.PdChannel, Dynamic_Offset_ODReading]
 
 class Temperature(JSONPrintedStruct):
     timestamp: t.Annotated[datetime, Meta(tz=True)]


### PR DESCRIPTION
1. Right now OD(optical density) measurements occur on a user specified frequency. So for our experiments prob like every 1 min or more is adequate especially since you have to shutoff air and LEDs during measurements you dint want to undo it. Issue is that when you turn on the growth_rate_calculating function it grabs the first recorded 30 samples or so (can change that value) to calculate a baseline measurement average value and variance that it uses. So ideally you want all those 30 values to occur rapidly so that the values are as close as possible. So i need to have the code run a different sampling frequency for the duration of collecting those samples then switch to the slower frequency

2. Right now the code takes a "blank measurement" when you turn on OD which basically measures light at photodiode to account for background light with the IR source being off. Only issue is it does this only for first measusrment and uses that same offset for every future measurement. Issue ofc being that background light will change so i want to change it so that it retakes the blank measurement before every actual measurement